### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/azezpz1/boardgamegeek_client/security/code-scanning/1](https://github.com/azezpz1/boardgamegeek_client/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since this workflow only reads repository contents and does not perform any write operations, we will limit the permissions to `contents: read`. This ensures that the workflow has the least privileges necessary to complete its tasks. The `permissions` block should be added at the root level of the workflow to apply to all jobs by default, unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
